### PR TITLE
Add loot tables and shovel mineable tag for eroded blocks

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
+++ b/src/main/resources/data/minecraft/tags/blocks/mineable/shovel.json
@@ -1,0 +1,9 @@
+{
+  "replace": false,
+  "values": [
+    "trmt:eroded_dirt",
+    "trmt:eroded_coarse_dirt",
+    "trmt:eroded_grass_block",
+    "trmt:eroded_sand"
+  ]
+}

--- a/src/main/resources/data/trmt/loot_tables/blocks/eroded_coarse_dirt.json
+++ b/src/main/resources/data/trmt/loot_tables/blocks/eroded_coarse_dirt.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        { "condition": "minecraft:survives_explosion" }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:coarse_dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/resources/data/trmt/loot_tables/blocks/eroded_dirt.json
+++ b/src/main/resources/data/trmt/loot_tables/blocks/eroded_dirt.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        { "condition": "minecraft:survives_explosion" }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/resources/data/trmt/loot_tables/blocks/eroded_grass_block.json
+++ b/src/main/resources/data/trmt/loot_tables/blocks/eroded_grass_block.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        { "condition": "minecraft:survives_explosion" }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:dirt"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}

--- a/src/main/resources/data/trmt/loot_tables/blocks/eroded_sand.json
+++ b/src/main/resources/data/trmt/loot_tables/blocks/eroded_sand.json
@@ -1,0 +1,18 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "bonus_rolls": 0.0,
+      "conditions": [
+        { "condition": "minecraft:survives_explosion" }
+      ],
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "minecraft:sand"
+        }
+      ],
+      "rolls": 1.0
+    }
+  ]
+}


### PR DESCRIPTION
Closes #9 
> Title is pretty self explanatory, but it also doesn't break faster when using a shovel.

AbstractBlock.Settings.copy() inherits hardness and sounds but not loot tables or tool tags


  - Added loot tables for eroded_dirt, eroded_coarse_dirt, eroded_grass_block, and eroded_sand
  - Registered all four in minecraft:mineable/shovel (with replace: false so the vanilla tag is extended, not overwritten)

Tested with local build