### PR TITLE
add eroded dirt blocks to dirt tag.

### DIFF
--- a/src/main/resources/data/minecraft/tags/blocks/dirt.json
+++ b/src/main/resources/data/minecraft/tags/blocks/dirt.json
@@ -1,0 +1,8 @@
+{
+  "replace": false,
+  "values": [
+    "trmt:eroded_dirt",
+    "trmt:eroded_coarse_dirt",
+    "trmt:eroded_grass_block"
+  ]
+}


### PR DESCRIPTION
Adds eroded_dirt, eroded_coarse_dirt, and eroded_grass_block to the #minecraft:dirt block tag, fixing two related issues with plants on eroded blocks.                                                                 
                                                                                                                                                                                                                         
 Root cause: `world.setBlockState(..., Block.NOTIFY_ALL)` notifies all neighbours on every erosion stage transition. Plants above call canPlaceAt → canPlantOnTop, which checks the `#minecraft:dirt` tag. Since eroded blocks were absent from this tag, any plant not in `BlockThresholds.VEGETATION` was silently destroyed on the first stage transition.

 Effect of this fix:
  - Plants outside VEGETATION (crops, berries, modded plants) now survive erosion transitions and can be replanted on eroded blocks
  - Plants inside VEGETATION now persist until the intentional trampling system removes them, rather than being destroyed on the first block update

  Closes #10

  Tested in local build
