### PR TITLE
Move Unique methods from mixin into util class

### DIFF
--- a/src/main/java/milkucha/trmt/erosion/TRMTWalkingErosionUtil.java
+++ b/src/main/java/milkucha/trmt/erosion/TRMTWalkingErosionUtil.java
@@ -43,6 +43,12 @@ public class TRMTWalkingErosionUtil {
             if (world.getBlockState(upper).isOf(state.getBlock())) {
                 world.removeBlock(upper, false);
             }
+            // Tall grass degrades to short grass rather than breaking entirely.
+            if (state.isOf(Blocks.TALL_GRASS)) {
+                world.setBlockState(pos, Blocks.GRASS.getDefaultState(), Block.NOTIFY_ALL);
+                manager.removeEntry(pos);
+                return;
+            }
         }
 
         float dropChance = TRMTConfig.get().erosionThresholds.vegetation.dropChance;
@@ -65,6 +71,7 @@ public class TRMTWalkingErosionUtil {
 
         // Threshold reached — advance visual stage or transform the block.
         if (state.isOf(Blocks.SAND)) {
+            if (!world.getBlockState(pos.up()).isAir()) return;
             Direction erodedFacing = rotationToFacing(BlockThresholds.posRotation(pos));
             world.setBlockState(pos,
                     TRMTBlocks.ERODED_SAND.getDefaultState()
@@ -77,6 +84,7 @@ public class TRMTWalkingErosionUtil {
         }
 
         if (state.isOf(TRMTBlocks.ERODED_SAND)) {
+            if (!world.getBlockState(pos.up()).isAir()) return;
             int stage = state.get(ErodedSandBlock.STAGE);
             if (stage < 4) {
                 world.setBlockState(pos, state.with(ErodedSandBlock.STAGE, stage + 1), Block.NOTIFY_ALL);

--- a/src/main/java/milkucha/trmt/erosion/TRMTWalkingErosionUtil.java
+++ b/src/main/java/milkucha/trmt/erosion/TRMTWalkingErosionUtil.java
@@ -1,0 +1,169 @@
+package milkucha.trmt.erosion;
+
+import milkucha.trmt.TRMTBlocks;
+import milkucha.trmt.TRMTConfig;
+import milkucha.trmt.block.ErodedDirtBlock;
+import milkucha.trmt.block.ErodedGrassBlock;
+import milkucha.trmt.block.ErodedSandBlock;
+import net.minecraft.block.Block;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.TallPlantBlock;
+import net.minecraft.block.enums.DoubleBlockHalf;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.util.math.ChunkPos;
+import net.minecraft.util.math.Direction;
+import net.minecraft.world.World;
+
+import java.util.concurrent.ThreadLocalRandom;
+
+public class TRMTWalkingErosionUtil {
+    public static void stepAdjacent(World world, ErosionMapManager manager,
+                                    BlockPos pos, float amount, long gameTime) {
+        BlockState adjState = world.getBlockState(pos);
+        TRMTConfig.ErosionToggles erosion = TRMTConfig.get().erosion;
+        if ((erosion.grassEnabled && (adjState.isOf(Blocks.GRASS_BLOCK) || adjState.isOf(TRMTBlocks.ERODED_GRASS_BLOCK)))
+                || (erosion.dirtEnabled && (adjState.isOf(Blocks.DIRT) || adjState.isOf(TRMTBlocks.ERODED_DIRT)))
+                || (erosion.sandEnabled && (adjState.isOf(Blocks.SAND) || adjState.isOf(TRMTBlocks.ERODED_SAND)))
+                || (erosion.leavesEnabled && BlockThresholds.isLeaves(adjState.getBlock()))) {
+            manager.onStep(pos, adjState.getBlock(), amount, gameTime);
+            tryTransform(world, manager, pos);
+        }
+    }
+
+    public static void tryBreakVegetation(World world, ErosionMapManager manager,
+                                          BlockPos pos, BlockState state) {
+        ErosionEntry entry = manager.getChunkMap(new ChunkPos(pos)).getEntry(pos);
+        if (entry == null || entry.getWalkedOnCount() < entry.getThreshold()) return;
+
+        // For double-height plants, remove the upper half first (no drops from upper half).
+        if (state.getBlock() instanceof TallPlantBlock
+                && state.get(TallPlantBlock.HALF) == DoubleBlockHalf.LOWER) {
+            BlockPos upper = pos.up();
+            if (world.getBlockState(upper).isOf(state.getBlock())) {
+                world.removeBlock(upper, false);
+            }
+        }
+
+        float dropChance = TRMTConfig.get().erosionThresholds.vegetation.dropChance;
+        boolean drops = dropChance >= 1.0f || (dropChance > 0.0f && ThreadLocalRandom.current().nextFloat() < dropChance);
+        world.breakBlock(pos, drops);
+        manager.removeEntry(pos);
+    }
+
+    /**
+     * Checks whether the block at {@code pos} has accumulated enough erosion to transform,
+     * and if so, advances it to the next stage in the chain and clears its entry.
+     */
+    public static void tryTransform(World world, ErosionMapManager manager, BlockPos pos) {
+        BlockState state = world.getBlockState(pos);
+
+        ErosionEntry entry = manager.getChunkMap(new ChunkPos(pos)).getEntry(pos);
+        if (entry == null || entry.getWalkedOnCount() < entry.getThreshold()) {
+            return;
+        }
+
+        // Threshold reached — advance visual stage or transform the block.
+        if (state.isOf(Blocks.SAND)) {
+            Direction erodedFacing = rotationToFacing(BlockThresholds.posRotation(pos));
+            world.setBlockState(pos,
+                    TRMTBlocks.ERODED_SAND.getDefaultState()
+                            .with(ErodedSandBlock.FACING, erodedFacing)
+                            .with(ErodedSandBlock.STAGE, 0),
+                    Block.NOTIFY_ALL);
+            manager.removeEntry(pos);
+            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_SAND, world.getTime());
+            return;
+        }
+
+        if (state.isOf(TRMTBlocks.ERODED_SAND)) {
+            int stage = state.get(ErodedSandBlock.STAGE);
+            if (stage < 4) {
+                world.setBlockState(pos, state.with(ErodedSandBlock.STAGE, stage + 1), Block.NOTIFY_ALL);
+            }
+            manager.removeEntry(pos);
+            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_SAND, world.getTime());
+            return;
+        }
+
+        if (BlockThresholds.isLeaves(state.getBlock())) {
+            float dropChance = TRMTConfig.get().erosionThresholds.leaves.dropChance;
+            boolean drops = dropChance >= 1.0f || (dropChance > 0.0f && ThreadLocalRandom.current().nextFloat() < dropChance);
+            world.breakBlock(pos, drops);
+            manager.removeEntry(pos);
+            return;
+        }
+
+        if (state.isOf(Blocks.GRASS_BLOCK)) {
+            // Threshold reached — place the real eroded grass block at stage 0.
+            Direction erodedFacing = rotationToFacing(BlockThresholds.posRotation(pos));
+            world.setBlockState(pos,
+                    TRMTBlocks.ERODED_GRASS_BLOCK.getDefaultState()
+                            .with(ErodedGrassBlock.FACING, erodedFacing)
+                            .with(ErodedGrassBlock.STAGE, 0),
+                    Block.NOTIFY_ALL);
+            manager.removeEntry(pos);
+            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_GRASS_BLOCK, world.getTime());
+            return;
+        }
+
+        if (state.isOf(TRMTBlocks.ERODED_GRASS_BLOCK)) {
+            Direction facing = state.get(ErodedGrassBlock.FACING);
+            int currentStage = state.get(ErodedGrassBlock.STAGE);
+            if (currentStage < 4) {
+                world.setBlockState(pos, state.with(ErodedGrassBlock.STAGE, currentStage + 1), Block.NOTIFY_ALL);
+                manager.removeEntry(pos);
+                manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_GRASS_BLOCK, world.getTime());
+                return;
+            }
+            // Stage 4 reached — convert to eroded_dirt, carrying FACING forward.
+            world.setBlockState(pos,
+                    TRMTBlocks.ERODED_DIRT.getDefaultState().with(ErodedDirtBlock.FACING, facing),
+                    Block.NOTIFY_ALL);
+            manager.removeEntry(pos);
+            return;
+        }
+
+        if (state.isOf(TRMTBlocks.ERODED_DIRT)) {
+            Direction facing = state.get(ErodedDirtBlock.FACING);
+            int currentStage = state.get(ErodedDirtBlock.STAGE);
+            if (currentStage < 3) {
+                // Advance to the next visual stage, preserving facing.
+                world.setBlockState(pos,
+                        state.with(ErodedDirtBlock.STAGE, currentStage + 1),
+                        Block.NOTIFY_ALL);
+                manager.removeEntry(pos);
+                return;
+            }
+            // Stage 3 reached — carry rotation forward to eroded_coarse_dirt.
+            world.setBlockState(pos,
+                    TRMTBlocks.ERODED_COARSE_DIRT.getDefaultState().with(ErodedDirtBlock.FACING, facing),
+                    Block.NOTIFY_ALL);
+            manager.removeEntry(pos);
+            return;
+        }
+
+        if (!state.isOf(Blocks.DIRT)) return;
+        Direction erodedFacing = rotationToFacing(BlockThresholds.posRotation(pos));
+        world.setBlockState(pos,
+                TRMTBlocks.ERODED_DIRT.getDefaultState()
+                        .with(ErodedDirtBlock.FACING, erodedFacing)
+                        .with(ErodedDirtBlock.STAGE, 1),
+                Block.NOTIFY_ALL);
+        manager.removeEntry(pos);
+    }
+
+    /**
+     * Maps a position rotation index (0–3, matching {@link BlockThresholds#posRotation})
+     * to the corresponding {@link Direction} for the FACING block-state property.
+     * 0 = SOUTH (0°), 1 = WEST (90° CW), 2 = NORTH (180°), 3 = EAST (270° CW).
+     */
+    public static Direction rotationToFacing(int rotation) {
+        return switch (rotation) {
+            case 1  -> Direction.WEST;
+            case 2  -> Direction.NORTH;
+            case 3  -> Direction.EAST;
+            default -> Direction.SOUTH;
+        };
+    }
+}

--- a/src/main/java/milkucha/trmt/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/milkucha/trmt/mixin/ServerPlayerEntityMixin.java
@@ -3,23 +3,15 @@ package milkucha.trmt.mixin;
 import milkucha.trmt.TRMTBlocks;
 import milkucha.trmt.TRMTConfig;
 import milkucha.trmt.TRMTEffects;
-import milkucha.trmt.block.ErodedDirtBlock;
-import milkucha.trmt.block.ErodedGrassBlock;
-import milkucha.trmt.block.ErodedSandBlock;
 import milkucha.trmt.erosion.BlockThresholds;
-import milkucha.trmt.erosion.ErosionEntry;
 import milkucha.trmt.erosion.ErosionMapManager;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
-import net.minecraft.block.TallPlantBlock;
-import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.LivingEntity;
-import java.util.concurrent.ThreadLocalRandom;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.math.BlockPos;
-import net.minecraft.util.math.ChunkPos;
 import net.minecraft.util.math.Direction;
 import net.minecraft.world.World;
 import org.spongepowered.asm.mixin.Mixin;
@@ -27,6 +19,8 @@ import org.spongepowered.asm.mixin.Unique;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import static milkucha.trmt.erosion.TRMTWalkingErosionUtil.*;
 
 @Mixin(ServerPlayerEntity.class)
 public class ServerPlayerEntityMixin {
@@ -98,7 +92,7 @@ public class ServerPlayerEntityMixin {
         BlockState vegState = world.getBlockState(vegPos);
         if (erosion.vegetationEnabled && BlockThresholds.isVegetation(vegState.getBlock())) {
             manager.onStep(vegPos, vegState.getBlock(), 1.0f * mult, gameTime);
-            trmt$tryBreakVegetation(world, manager, vegPos, vegState);
+            tryBreakVegetation(world, manager, vegPos, vegState);
             manager.broadcastEntryUpdate(vegPos, vegState.getBlock());
         }
 
@@ -112,7 +106,7 @@ public class ServerPlayerEntityMixin {
         }
 
         manager.onStep(groundPos, block, 1.0f * mult, gameTime);
-        trmt$tryTransform(world, manager, groundPos);
+        tryTransform(world, manager, groundPos);
         manager.broadcastEntryUpdate(groundPos, block);
 
         // Spread erosion to adjacent blocks based on the player's facing direction.
@@ -123,161 +117,10 @@ public class ServerPlayerEntityMixin {
         Direction left  = facing.rotateYCounterclockwise();
         Direction right = facing.rotateYClockwise();
 
-        trmt$stepAdjacent(world, manager, groundPos.offset(facing), 0.2f * mult, gameTime);
-        trmt$stepAdjacent(world, manager, groundPos.offset(left),   0.5f * mult, gameTime);
-        trmt$stepAdjacent(world, manager, groundPos.offset(right),  0.5f * mult, gameTime);
+        stepAdjacent(world, manager, groundPos.offset(facing), 0.2f * mult, gameTime);
+        stepAdjacent(world, manager, groundPos.offset(left),   0.5f * mult, gameTime);
+        stepAdjacent(world, manager, groundPos.offset(right),  0.5f * mult, gameTime);
     }
 
-    @Unique
-    private static void trmt$stepAdjacent(World world, ErosionMapManager manager,
-                                           BlockPos pos, float amount, long gameTime) {
-        BlockState adjState = world.getBlockState(pos);
-        TRMTConfig.ErosionToggles erosion = TRMTConfig.get().erosion;
-        if ((erosion.grassEnabled && (adjState.isOf(Blocks.GRASS_BLOCK) || adjState.isOf(TRMTBlocks.ERODED_GRASS_BLOCK)))
-                || (erosion.dirtEnabled && (adjState.isOf(Blocks.DIRT) || adjState.isOf(TRMTBlocks.ERODED_DIRT)))
-                || (erosion.sandEnabled && (adjState.isOf(Blocks.SAND) || adjState.isOf(TRMTBlocks.ERODED_SAND)))
-                || (erosion.leavesEnabled && BlockThresholds.isLeaves(adjState.getBlock()))) {
-            manager.onStep(pos, adjState.getBlock(), amount, gameTime);
-            trmt$tryTransform(world, manager, pos);
-        }
-    }
 
-    @Unique
-    private static void trmt$tryBreakVegetation(World world, ErosionMapManager manager,
-                                                 BlockPos pos, BlockState state) {
-        ErosionEntry entry = manager.getChunkMap(new ChunkPos(pos)).getEntry(pos);
-        if (entry == null || entry.getWalkedOnCount() < entry.getThreshold()) return;
-
-        // For double-height plants, remove the upper half first (no drops from upper half).
-        if (state.getBlock() instanceof TallPlantBlock
-                && state.get(TallPlantBlock.HALF) == DoubleBlockHalf.LOWER) {
-            BlockPos upper = pos.up();
-            if (world.getBlockState(upper).isOf(state.getBlock())) {
-                world.removeBlock(upper, false);
-            }
-        }
-
-        float dropChance = TRMTConfig.get().erosionThresholds.vegetation.dropChance;
-        boolean drops = dropChance >= 1.0f || (dropChance > 0.0f && ThreadLocalRandom.current().nextFloat() < dropChance);
-        world.breakBlock(pos, drops);
-        manager.removeEntry(pos);
-    }
-
-    /**
-     * Checks whether the block at {@code pos} has accumulated enough erosion to transform,
-     * and if so, advances it to the next stage in the chain and clears its entry.
-     */
-    @Unique
-    private static void trmt$tryTransform(World world, ErosionMapManager manager, BlockPos pos) {
-        BlockState state = world.getBlockState(pos);
-
-        ErosionEntry entry = manager.getChunkMap(new ChunkPos(pos)).getEntry(pos);
-        if (entry == null || entry.getWalkedOnCount() < entry.getThreshold()) {
-            return;
-        }
-
-        // Threshold reached — advance visual stage or transform the block.
-        if (state.isOf(Blocks.SAND)) {
-            Direction erodedFacing = trmt$rotationToFacing(BlockThresholds.posRotation(pos));
-            world.setBlockState(pos,
-                    TRMTBlocks.ERODED_SAND.getDefaultState()
-                            .with(ErodedSandBlock.FACING, erodedFacing)
-                            .with(ErodedSandBlock.STAGE, 0),
-                    Block.NOTIFY_ALL);
-            manager.removeEntry(pos);
-            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_SAND, world.getTime());
-            return;
-        }
-
-        if (state.isOf(TRMTBlocks.ERODED_SAND)) {
-            int stage = state.get(ErodedSandBlock.STAGE);
-            if (stage < 4) {
-                world.setBlockState(pos, state.with(ErodedSandBlock.STAGE, stage + 1), Block.NOTIFY_ALL);
-            }
-            manager.removeEntry(pos);
-            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_SAND, world.getTime());
-            return;
-        }
-
-        if (BlockThresholds.isLeaves(state.getBlock())) {
-            float dropChance = TRMTConfig.get().erosionThresholds.leaves.dropChance;
-            boolean drops = dropChance >= 1.0f || (dropChance > 0.0f && ThreadLocalRandom.current().nextFloat() < dropChance);
-            world.breakBlock(pos, drops);
-            manager.removeEntry(pos);
-            return;
-        }
-
-        if (state.isOf(Blocks.GRASS_BLOCK)) {
-            // Threshold reached — place the real eroded grass block at stage 0.
-            Direction erodedFacing = trmt$rotationToFacing(BlockThresholds.posRotation(pos));
-            world.setBlockState(pos,
-                    TRMTBlocks.ERODED_GRASS_BLOCK.getDefaultState()
-                            .with(ErodedGrassBlock.FACING, erodedFacing)
-                            .with(ErodedGrassBlock.STAGE, 0),
-                    Block.NOTIFY_ALL);
-            manager.removeEntry(pos);
-            manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_GRASS_BLOCK, world.getTime());
-            return;
-        }
-
-        if (state.isOf(TRMTBlocks.ERODED_GRASS_BLOCK)) {
-            Direction facing = state.get(ErodedGrassBlock.FACING);
-            int currentStage = state.get(ErodedGrassBlock.STAGE);
-            if (currentStage < 4) {
-                world.setBlockState(pos, state.with(ErodedGrassBlock.STAGE, currentStage + 1), Block.NOTIFY_ALL);
-                manager.removeEntry(pos);
-                manager.writeCooldownEntry(pos, TRMTBlocks.ERODED_GRASS_BLOCK, world.getTime());
-                return;
-            }
-            // Stage 4 reached — convert to eroded_dirt, carrying FACING forward.
-            world.setBlockState(pos,
-                    TRMTBlocks.ERODED_DIRT.getDefaultState().with(ErodedDirtBlock.FACING, facing),
-                    Block.NOTIFY_ALL);
-            manager.removeEntry(pos);
-            return;
-        }
-
-        if (state.isOf(TRMTBlocks.ERODED_DIRT)) {
-            Direction facing = state.get(ErodedDirtBlock.FACING);
-            int currentStage = state.get(ErodedDirtBlock.STAGE);
-            if (currentStage < 3) {
-                // Advance to the next visual stage, preserving facing.
-                world.setBlockState(pos,
-                        state.with(ErodedDirtBlock.STAGE, currentStage + 1),
-                        Block.NOTIFY_ALL);
-                manager.removeEntry(pos);
-                return;
-            }
-            // Stage 3 reached — carry rotation forward to eroded_coarse_dirt.
-            world.setBlockState(pos,
-                    TRMTBlocks.ERODED_COARSE_DIRT.getDefaultState().with(ErodedDirtBlock.FACING, facing),
-                    Block.NOTIFY_ALL);
-            manager.removeEntry(pos);
-            return;
-        }
-
-        if (!state.isOf(Blocks.DIRT)) return;
-        Direction erodedFacing = trmt$rotationToFacing(BlockThresholds.posRotation(pos));
-        world.setBlockState(pos,
-                TRMTBlocks.ERODED_DIRT.getDefaultState()
-                        .with(ErodedDirtBlock.FACING, erodedFacing)
-                        .with(ErodedDirtBlock.STAGE, 1),
-                Block.NOTIFY_ALL);
-        manager.removeEntry(pos);
-    }
-
-    /**
-     * Maps a position rotation index (0–3, matching {@link BlockThresholds#posRotation})
-     * to the corresponding {@link Direction} for the FACING block-state property.
-     * 0 = SOUTH (0°), 1 = WEST (90° CW), 2 = NORTH (180°), 3 = EAST (270° CW).
-     */
-    @Unique
-    private static Direction trmt$rotationToFacing(int rotation) {
-        return switch (rotation) {
-            case 1  -> Direction.WEST;
-            case 2  -> Direction.NORTH;
-            case 3  -> Direction.EAST;
-            default -> Direction.SOUTH;
-        };
-    }
 }

--- a/src/main/java/milkucha/trmt/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/milkucha/trmt/mixin/ServerPlayerEntityMixin.java
@@ -33,7 +33,7 @@ public class ServerPlayerEntityMixin {
     @Inject(method = "tick", at = @At("TAIL"))
     private void trmt$onTick(CallbackInfo ci) {
         ServerPlayerEntity player = (ServerPlayerEntity) (Object) this;
-
+        
         // Determine whether the player is mounted and, if so, delegate ground detection to the vehicle.
         Entity vehicle = player.getVehicle();
         boolean mounted = vehicle != null;


### PR DESCRIPTION
This PR moves the `@Unique` methods from `ServerPlayerEntityMixin` into their own class, `TRMTWalkingErosionUtil`.

I want this change because it makes it wayyy easier for me to add compat for TRMT. I can have my custom interaction (in this case, wheels on a vehicle) trigger the walking code without rewriting all of it. Since there is absolutely no way for another mod to use the `@Unique private` methods in the mixin class, having to copy out all the functions is the only solution right now.

I can see this move as being useful for:
1. Custom "vehicle" entities such as immersive vehicles
2. Custom "vehicles" such as Valkyrien Skies or Create: Aeronautics
3. Custom entities/mounts which need to trigger this code without the `tick` method (not sure _why_ this would happen, but you never know).

The specifics of how I've moved these methods is up for discussion, I'm not particularly attached to where I've put them. I just want them to not be confined to only the mixin itself :pray: :pleading_face:  