### PR TITLE
Match eroded grass loot table to vanilla's grass

### DIFF
--- a/src/main/resources/data/trmt/loot_table/blocks/eroded_grass_block.json
+++ b/src/main/resources/data/trmt/loot_table/blocks/eroded_grass_block.json
@@ -2,19 +2,46 @@
   "type": "minecraft:block",
   "pools": [
     {
-      "rolls": 1,
-      "bonus_rolls": 0,
+      "bonus_rolls": 0.0,
       "entries": [
         {
-          "type": "minecraft:item",
-          "name": "minecraft:grass_block"
+          "type": "minecraft:alternatives",
+          "children": [
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:match_tool",
+                  "predicate": {
+                    "predicates": {
+                      "minecraft:enchantments": [
+                        {
+                          "enchantments": "minecraft:silk_touch",
+                          "levels": {
+                            "min": 1
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "name": "minecraft:grass_block"
+            },
+            {
+              "type": "minecraft:item",
+              "conditions": [
+                {
+                  "condition": "minecraft:survives_explosion"
+                }
+              ],
+              "name": "minecraft:dirt"
+            }
+          ]
         }
       ],
-      "conditions": [
-        {
-          "condition": "minecraft:survives_explosion"
-        }
-      ]
+      "rolls": 1.0
     }
-  ]
+  ],
+  "random_sequence": "trmt:blocks/eroded_grass_block"
 }


### PR DESCRIPTION
I have read the Contributor License Agreement in CLA.md and I agree to its terms.

Currently, breaking or exploding eroded grass always drops a grass block. This doesn't match vanilla's behavior, which requires silk touch to drop grass, and otherwise drops dirt. This is a simple change for that vanilla parity.