### PR TITLE
Fix erosion sync flooding on player login

### DIFF
--- a/src/main/java/milkucha/trmt/TRMTForgeEvents.java
+++ b/src/main/java/milkucha/trmt/TRMTForgeEvents.java
@@ -21,6 +21,7 @@ import net.minecraftforge.event.RegisterCommandsEvent;
 import net.minecraftforge.event.entity.player.PlayerEvent;
 import net.minecraftforge.event.entity.player.PlayerInteractEvent;
 import net.minecraftforge.event.level.BlockEvent;
+import net.minecraftforge.event.level.ChunkWatchEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.event.server.ServerStoppedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -48,9 +49,13 @@ public class TRMTForgeEvents {
     @SubscribeEvent
     public static void onPlayerLoggedIn(PlayerEvent.PlayerLoggedInEvent event) {
         if (event.getEntity() instanceof ServerPlayer player) {
-            ErosionMapManager.getInstance().sendFullSyncToPlayer(player);
             TRMTNetwork.sendVersionCheck(player);
         }
+    }
+
+    @SubscribeEvent
+    public static void onChunkWatch(ChunkWatchEvent.Watch event) {
+        ErosionMapManager.getInstance().sendChunkSyncToPlayer(event.getPlayer(), event.getPos());
     }
 
     @SubscribeEvent

--- a/src/main/java/milkucha/trmt/erosion/ErosionMapManager.java
+++ b/src/main/java/milkucha/trmt/erosion/ErosionMapManager.java
@@ -243,25 +243,24 @@ public class ErosionMapManager {
 
     // --- Networking ---
 
-    public void sendFullSyncToPlayer(ServerPlayer player) {
+    public void sendChunkSyncToPlayer(ServerPlayer player, ChunkPos chunkPos) {
         if (state == null) return;
-        for (Map.Entry<ChunkPos, ChunkErosionMap> chunkEntry : state.getAllChunkMaps().entrySet()) {
-            ChunkPos chunkPos = chunkEntry.getKey();
-            Map<BlockPos, ErosionEntry> entries = chunkEntry.getValue().getEntries();
-            if (entries.isEmpty()) continue;
 
-            List<TRMTNetwork.SyncChunkMessage.Entry> payloadEntries = new ArrayList<>(entries.size());
-            for (Map.Entry<BlockPos, ErosionEntry> e : entries.entrySet()) {
-                payloadEntries.add(new TRMTNetwork.SyncChunkMessage.Entry(
-                        e.getKey(),
-                        e.getValue().getErosionStage(),
-                        e.getValue().getWalkedOnCount(),
-                        e.getValue().getThreshold(),
-                        e.getValue().getLastTouchedGameTime()
-                ));
-            }
-            TRMTNetwork.sendSyncChunk(player, chunkPos.x, chunkPos.z, payloadEntries);
+        ChunkErosionMap map = state.getChunkMap(chunkPos);
+        Map<BlockPos, ErosionEntry> entries = map != null ? map.getEntries() : Collections.emptyMap();
+        List<TRMTNetwork.SyncChunkMessage.Entry> payloadEntries = new ArrayList<>(entries.size());
+
+        for (Map.Entry<BlockPos, ErosionEntry> e : entries.entrySet()) {
+            payloadEntries.add(new TRMTNetwork.SyncChunkMessage.Entry(
+                    e.getKey(),
+                    e.getValue().getErosionStage(),
+                    e.getValue().getWalkedOnCount(),
+                    e.getValue().getThreshold(),
+                    e.getValue().getLastTouchedGameTime()
+            ));
         }
+
+        TRMTNetwork.sendSyncChunk(player, chunkPos.x, chunkPos.z, payloadEntries);
     }
 
     private void broadcastStageUpdate(BlockPos pos, int stage, float walkedOnCount, float threshold, long lastTouchedGameTime) {


### PR DESCRIPTION
## What this fixes

Closes issue #63.

On large worlds, `sendFullSyncToPlayer()` sends every persisted erosion chunk to a player during login. In our production world this produced 100k+ `trmt:main` packets immediately after joining, delaying vanilla chunk data and keepalives enough to cause empty-world/void symptoms and `Timed out` disconnects.

A packet trace from the failing case showed ~102k TRMT payloads and ~132 MB received while **zero** `ClientboundLevelChunkWithLightPacket` and **zero** `ClientboundKeepAlivePacket` reached the client.

## Change

- Stop sending the world-wide erosion sync from `PlayerLoggedInEvent`.
- Sync erosion data when Forge fires `ChunkWatchEvent.Watch`, so the client only receives data for chunks it actually tracks.
- Send an empty chunk sync when there is no erosion data so stale client cache entries are cleared on re-watch.

We tested the same approach on the affected server and the player could join normally afterward.

I have read the Contributor License Agreement in CLA.md and I agree to its terms.

## Verification

`gradle build` passes on the `1.20.1-forge` branch with Forge 47.4.10 / Java 17.
