### PR TITLE
Update to NeoForge 26.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
 	id 'eclipse'
 	id 'idea'
 	id 'maven-publish'
-	id 'net.neoforged.gradle.userdev' version '7.1.36'
+	id 'net.neoforged.moddev' version '2.0.142'
 }
 
 version = mod_version
@@ -15,22 +15,32 @@ java {
 	}
 }
 
-runs {
-	configureEach {
-		workingDirectory project.file('run')
-		systemProperty 'neoforge.logging.markers', 'REGISTRIES'
-		systemProperty 'neoforge.logging.console.level', 'debug'
-		modSource project.sourceSets.main
+neoForge {
+	version = neoforge_version
+
+	runs {
+		configureEach {
+			gameDirectory = project.file('run')
+			systemProperty 'neoforge.logging.markers', 'REGISTRIES'
+			logLevel = org.slf4j.event.Level.DEBUG
+		}
+
+		client { client() }
+
+		server {
+			server()
+			programArgument '--nogui'
+		}
+
+		gameTestServer {
+			type = 'gameTestServer'
+		}
 	}
 
-	client {}
-
-	server {
-		arguments '--nogui'
-	}
-
-	gameTestServer {
-		arguments '--nogui'
+	mods {
+		"${mod_id}" {
+			sourceSet(sourceSets.main)
+		}
 	}
 }
 
@@ -44,10 +54,6 @@ configurations.all {
 		'org.ow2.asm:asm-tree:9.8',
 		'org.ow2.asm:asm-util:9.8'
 	)
-}
-
-dependencies {
-	implementation "net.neoforged:neoforge:${neoforge_version}"
 }
 
 tasks.named('processResources', ProcessResources).configure {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,18 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-minecraft_version=26.1
+minecraft_version=26.2
 minecraft_version_range=[26.1,27)
-neoforge_version=26.1.0.19-beta
+neoforge_version=26.2.0.41-beta
 neoforge_version_range=[26.1,)
 loader_version_range=[1,)
 mapping_channel=official
-mapping_version=26.1
+mapping_version=26.2
 
 mod_id=trmt
 mod_name=The Roads More Travelled
 mod_license=CC-BY-NC-4.0
-mod_version=0.5.1-26.1-neoforge
+mod_version=0.5.1-26.2-neoforge
 mod_group_id=milkucha.trmt
 mod_authors=milkucha
 mod_description=An erosion mod for Minecraft

--- a/src/main/java/milkucha/trmt/TRMTNeoForgeEvents.java
+++ b/src/main/java/milkucha/trmt/TRMTNeoForgeEvents.java
@@ -25,7 +25,7 @@ import net.neoforged.fml.common.EventBusSubscriber;
 import net.neoforged.neoforge.event.RegisterCommandsEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerEvent;
 import net.neoforged.neoforge.event.entity.player.PlayerInteractEvent;
-import net.neoforged.neoforge.event.level.BlockEvent;
+import net.neoforged.neoforge.event.level.block.BreakBlockEvent;
 import net.neoforged.neoforge.event.server.ServerStartedEvent;
 import net.neoforged.neoforge.event.server.ServerStoppedEvent;
 
@@ -64,7 +64,7 @@ public class TRMTNeoForgeEvents {
     }
 
     @SubscribeEvent
-    public static void onBlockBreak(BlockEvent.BreakEvent event) {
+    public static void onBlockBreak(BreakBlockEvent event) {
         ErosionMapManager.getInstance().removeEntry(event.getPos());
     }
 


### PR DESCRIPTION
I have read the Contributor License Agreement in CLA.md and I agree to its terms.

This PR updates the gradle files to allow compilation against the new NeoForge API.
It also updates the BreakBlockEvent that is now in its own class.